### PR TITLE
Solve the MacOS MCP client auto-setup issue

### DIFF
--- a/plugin/utils/auto_setup.py
+++ b/plugin/utils/auto_setup.py
@@ -33,6 +33,62 @@ def _venv_python() -> str:
     return os.path.join(d, "bin", "python3")
 
 
+def _looks_like_binja_embedded(py_path: str) -> bool:
+    """Detect venvs built from Binary Ninja's embedded interpreter on macOS."""
+    try:
+        bin_dir = os.path.dirname(py_path)
+        bn = os.path.join(bin_dir, "binaryninja")
+        if os.path.exists(bn) and os.path.exists(py_path):
+            sp = os.stat(py_path)
+            sb = os.stat(bn)
+            if sp.st_size == sb.st_size:
+                return True
+        base = os.path.basename(py_path).lower()
+        if base.startswith("binaryninja") or "Binary Ninja.app" in py_path:
+            return True
+    except Exception:
+        pass
+    return False
+
+
+def _select_system_python(min_major: int = 3, min_minor: int = 10) -> str | None:
+    def ok(p: str) -> bool:
+        try:
+            r = subprocess.run([p, "-c", "import sys;print(f'{sys.version_info[0]}.{sys.version_info[1]}')"], capture_output=True, text=True, check=False)
+            if r.returncode == 0:
+                s = (r.stdout or "").strip()
+                parts = s.split(".")
+                if len(parts) >= 2:
+                    maj, minor = int(parts[0]), int(parts[1])
+                    return (maj > min_major) or (maj == min_major and minor >= min_minor)
+        except Exception:
+            pass
+        return False
+
+    env_p = os.environ.get("BINJA_MCP_PYTHON")
+    if env_p and ok(env_p):
+        return env_p
+    if ok(sys.executable):
+        return sys.executable
+    candidates: list[str] = []
+    if sys.platform == "darwin":
+        candidates += [
+            "/opt/homebrew/bin/python3",
+            "/usr/local/bin/python3",
+        ]
+    candidates += [
+        "python3",
+        "python3.12",
+        "python3.11",
+        "python3.10",
+        "/usr/bin/python3",
+    ]
+    for c in candidates:
+        if ok(c):
+            return c
+    return None
+
+
 def _ensure_local_venv() -> str:
     """Create a local venv under the plugin root if missing.
 
@@ -42,10 +98,12 @@ def _ensure_local_venv() -> str:
     vdir = _venv_dir()
     py = _venv_python()
     try:
-        # If this looks like a BN-embedded venv (binaryninja.exe present) or
-        # python.exe is missing, (re)build the venv using a system Python.
+        # If this looks missing or like a BN-embedded venv, (re)build using a real system Python.
         bn_launcher = os.path.join(vdir, "Scripts", "binaryninja.exe") if sys.platform == "win32" else None
-        if not os.path.exists(py) or (sys.platform == "win32" and os.path.exists(bn_launcher)):
+        needs_build = not os.path.exists(py) or (sys.platform == "win32" and os.path.exists(bn_launcher))
+        if not needs_build and sys.platform == "darwin" and _looks_like_binja_embedded(py):
+            needs_build = True
+        if needs_build:
             os.makedirs(vdir, exist_ok=True)
             created = False
             # On Windows, prefer system Python launcher to avoid embedding
@@ -56,11 +114,22 @@ def _ensure_local_venv() -> str:
                     created = True
                 except Exception:
                     created = False
+            # On macOS, prefer a real Python >=3.10 (Homebrew if available)
+            if sys.platform == "darwin" and not created:
+                cand = _select_system_python(3, 10)
+                if cand:
+                    try:
+                        subprocess.run([cand, "-m", "venv", vdir], check=False, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
+                        created = True
+                    except Exception:
+                        created = False
             if not created:
                 builder = venv.EnvBuilder(with_pip=True, upgrade=False)
                 builder.create(vdir)
             # Re-evaluate interpreter path after creation (may be python.exe now)
             py = _venv_python()
+            if sys.platform == "darwin" and _looks_like_binja_embedded(py):
+                return _get_python_executable()
             # Best-effort: install bridge requirements
             req = os.path.join(_repo_root(), "bridge", "requirements.txt")
             if os.path.exists(req):


### PR DESCRIPTION
**Root Cause**
- Embedded interpreter: The plugin’s venv was created from Binary Ninja’s embedded launcher, so …/.venv/bin/python3 was effectively binaryninja (GUI launcher), not a real stdio-safe Python. MCP clients spawn it over stdio, and macOS kills or it exits immediately. - Mismatch/deps: In some cases the venv (or /usr/bin/python3) was too old or missing mcp[cli], causing import-time failures that closed the connection.

**Symptoms**
- Manual run showed “[1] killed” and the MCP client reported “-32000: Connection closed”. - ls -l .venv/bin showed python, python3, binaryninja all identical size (the BN launcher).

**Fix**
- Rebuilt the venv with a real Python ≥ 3.10 (prefer Homebrew at /opt/homebrew/bin/python3), installed bridge/requirements.txt, and pointed MCP to that interpreter. - Added early logging to /tmp/binja_mcp_bridge.log to capture import/runtime errors.

**Prevention**
- Auto-setup/installer now detect BN-embedded venvs and prefer a real system Python (or BINJA_MCP_PYTHON) when creating the venv, avoiding the embedded interpreter entirely.