### PR TITLE
Add: get_callers & get_callees tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,6 +153,8 @@ The following table lists the available MCP functions for use:
 | `get_xrefs_to_union(union_name)`                                     | Get xrefs/usages related to a union (members, globals, code refs).                                           |
 | `get_stack_frame_vars(function_identifier)`                          | Get stack frame variable information for a function (names, offsets, sizes, types).                           |
 | `get_type_info(type_name)`                                           | Resolve a type and return declaration, kind, and members.                                                    |
+| `get_callers(identifiers)`                                           | List callers plus call sites for one or more function identifiers.                                           |
+| `get_callees(identifiers)`                                           | List callees plus call sites for one or more function identifiers.                                           |
 | `make_function_at(address, platform)`                                | Create a function at an address. `platform` optional; use `default` to pick the BinaryView/platform default. |
 | `list_platforms()`                                                   | List all available platform names.                                                                           |
 | `list_binaries()`                                                    | List managed/open binaries with ids and active flag.                                                         |
@@ -200,6 +202,8 @@ These are the list of HTTP endpoints that can be called:
 - `/getTypeInfo?name=<type>`: Resolve a type and return declaration and details.
 - `/getXrefsToUnion?name=<union>`: Union xrefs/usages (members, globals, refs).
 - `/getStackFrameVars?name=<function>|address=<addr>`: Get stack frame variable information for a function.
+- `/getCallers?identifiers=<name|addr>[,...]`: Return caller summaries (functions, call sites, HLIL/IL snippets) for one or more identifiers. Accepts `identifiers`, `identifier`, `names`, or `addresses` query params.
+- `/getCallees?identifiers=<name|addr>[,...]`: Return callee summaries with the same schema as `/getCallers`, detailing every outgoing call target per request identifier.
 - `/localTypes?offset=<n>&limit=<m>`: List local types.
 - `/strings?offset=<n>&limit=<m>`: Paginated strings.
 - `/strings/filter?offset=<n>&limit=<m>&filter=<substr>`: Filtered strings.

--- a/bridge/binja_mcp_bridge.py
+++ b/bridge/binja_mcp_bridge.py
@@ -805,6 +805,53 @@ def get_type_info(type_name: str) -> str:
     return _json.dumps(data, indent=2, ensure_ascii=False)
 
 
+def _normalize_identifier_input(value: str | list[str]) -> list[str]:
+    tokens: list[str] = []
+    if isinstance(value, str):
+        raw = value.replace(";", ",").split(",")
+        tokens.extend([tok.strip() for tok in raw if tok.strip()])
+    elif isinstance(value, (list, tuple, set)):
+        for item in value:
+            if item is None:
+                continue
+            tokens.extend(_normalize_identifier_input(str(item)))
+    return tokens
+
+
+@mcp.tool()
+def get_callers(identifiers: str) -> str:
+    """
+    List callers and caller sites for one or more function identifiers (name or address).
+    Provide comma-separated identifiers like "sub_401000,main".
+    """
+    items = _normalize_identifier_input(identifiers)
+    if not items:
+        return "Error: provide at least one identifier"
+    data = get_json("getCallers", {"identifiers": ",".join(items)}, timeout=None)
+    if not data:
+        return "Error: no response"
+    import json as _json
+
+    return _json.dumps(data, indent=2, ensure_ascii=False)
+
+
+@mcp.tool()
+def get_callees(identifiers: str) -> str:
+    """
+    List callees and call sites for one or more function identifiers (name or address).
+    Provide comma-separated identifiers like "sub_401000,main".
+    """
+    items = _normalize_identifier_input(identifiers)
+    if not items:
+        return "Error: provide at least one identifier"
+    data = get_json("getCallees", {"identifiers": ",".join(items)}, timeout=None)
+    if not data:
+        return "Error: no response"
+    import json as _json
+
+    return _json.dumps(data, indent=2, ensure_ascii=False)
+
+
 @mcp.tool()
 def set_function_prototype(name_or_address: str, prototype: str) -> str:
     """

--- a/plugin/api/endpoints.py
+++ b/plugin/api/endpoints.py
@@ -104,6 +104,14 @@ class BinaryNinjaEndpoints:
             bn.log_error(f"Error getting function info: {e}")
             return None
 
+    def get_callers(self, identifiers: list[str]) -> dict[str, Any]:
+        """Proxy BinaryOperations.get_callers for endpoint reuse."""
+        return self.binary_ops.get_callers(identifiers)
+
+    def get_callees(self, identifiers: list[str]) -> dict[str, Any]:
+        """Proxy BinaryOperations.get_callees for endpoint reuse."""
+        return self.binary_ops.get_callees(identifiers)
+
     def get_imports(self, offset: int = 0, limit: int = 100) -> list[dict[str, Any]]:
         """Get list of imported functions"""
         if not self.binary_ops.current_view:


### PR DESCRIPTION
- `get_callers`: Takes one or more function names/addresses, returns JSON {"results":[{identifier,function,callers,caller_sites}], "errors":[...]} where each entry includes normalized function metadata, every caller, and HLIL/IL snippets for each call site.
- `get_callees`: Accepts the same identifier inputs, returns {"results":[{identifier,function,callees,call_sites}], "errors":[...]} listing every outgoing callee plus per-site IL context, falling back to raw addresses when no symbol exists.