### PR TITLE
fix: enhance CORS handling to prevent DNS rebinding and reject prefli…

### DIFF
--- a/plugin/server/http_server.py
+++ b/plugin/server/http_server.py
@@ -232,22 +232,14 @@ class MCPRequestHandler(BaseHTTPRequestHandler):
         """Validate Origin header per MCP spec to prevent DNS rebinding."""
         if self.headers.get("Origin") is None:
             return True
-        self._set_headers(status_code=403)
-        try:
-            self.wfile.write(
-                json.dumps({"error": "Forbidden: browser requests are not allowed"}).encode("utf-8")
-            )
-        except (BrokenPipeError, OSError):
-            pass
+        self._send_json_response(
+            {"error": "Forbidden: browser requests are not allowed"}, 403
+        )
         return False
 
     def do_OPTIONS(self):
         """Reject CORS preflight requests."""
-        self._set_headers(status_code=403)
-        try:
-            self.wfile.write(json.dumps({"error": "Forbidden"}).encode("utf-8"))
-        except (BrokenPipeError, OSError):
-            pass
+        self._send_json_response({"error": "Forbidden"}, 403)
 
     def _check_binary_loaded(self):
         """Check if a binary is loaded and return appropriate error response if not"""

--- a/plugin/server/http_server.py
+++ b/plugin/server/http_server.py
@@ -36,7 +36,6 @@ class MCPRequestHandler(BaseHTTPRequestHandler):
         try:
             self.send_response(status_code)
             self.send_header("Content-Type", content_type)
-            self.send_header("Access-Control-Allow-Origin", "*")
             # Encourage clients to close promptly; reduces BrokenPipe on abrupt disconnects
             self.send_header("Connection", "close")
             self.end_headers()
@@ -229,6 +228,27 @@ class MCPRequestHandler(BaseHTTPRequestHandler):
         except Exception:
             return '""'
 
+    def _check_origin(self):
+        """Validate Origin header per MCP spec to prevent DNS rebinding."""
+        if self.headers.get("Origin") is None:
+            return True
+        self._set_headers(status_code=403)
+        try:
+            self.wfile.write(
+                json.dumps({"error": "Forbidden: browser requests are not allowed"}).encode("utf-8")
+            )
+        except (BrokenPipeError, OSError):
+            pass
+        return False
+
+    def do_OPTIONS(self):
+        """Reject CORS preflight requests."""
+        self._set_headers(status_code=403)
+        try:
+            self.wfile.write(json.dumps({"error": "Forbidden"}).encode("utf-8"))
+        except (BrokenPipeError, OSError):
+            pass
+
     def _check_binary_loaded(self):
         """Check if a binary is loaded and return appropriate error response if not"""
         if not self.binary_ops or not self.binary_ops.current_view:
@@ -238,6 +258,8 @@ class MCPRequestHandler(BaseHTTPRequestHandler):
 
     def do_GET(self):
         try:
+            if not self._check_origin():
+                return
             # For all endpoints except /status, /convertNumber, /platforms, /binaries, /views, /selectBinary, check loaded
             if (
                 not (
@@ -1902,6 +1924,8 @@ class MCPRequestHandler(BaseHTTPRequestHandler):
 
     def do_POST(self):
         try:
+            if not self._check_origin():
+                return
             if not self._check_binary_loaded():
                 return
 


### PR DESCRIPTION
# Abstruct
No CORS headers: this server is accessed only by local MCP bridge
processes (not browsers). Omitting Access-Control-Allow-Origin
prevents malicious websites from making cross-origin requests.

## Validate Origin header per MCP spec to prevent DNS rebinding. `_check_origin`
Per the MCP specification (Streamable HTTP - Security Warning):
servers MUST validate the Origin header on all incoming connections.
If the Origin header is present and invalid, servers MUST respond
with HTTP 403 Forbidden.

This server is only accessed by local MCP bridge processes which
do not send an Origin header.  Any request carrying an Origin
header is from a browser and must be rejected.

## Reject CORS preflight requests. `do_OPTIONS `
This server is accessed only by local MCP bridge processes, never
from a browser.  Returning 403 ensures that any browser-initiated
preflight fails and the actual request is blocked.