### PR TITLE
bridge: Fix `set_function_prototype` tool with recent axiom versions

### DIFF
--- a/bridge/src/tools.ts
+++ b/bridge/src/tools.ts
@@ -936,7 +936,7 @@ export function registerTools(server: McpServer, client: BinjaHttpClient): void 
     },
     async ({ name_or_address, prototype }) => {
       const ident = name_or_address.trim();
-      const params: Record<string, string> = { prototype };
+      const params: Record<string, string> = { signature: prototype };
       if (ident.toLowerCase().startsWith("0x") || /^\d+$/.test(ident)) {
         params.address = ident;
       } else {


### PR DESCRIPTION
Update the parameter name because recent axiom versions (v1.13.5+) intentionally filter out `prototype`. This is the only use of the parameter `prototype`. `signature` is already accepted as alternative by the Binary Ninja side.

Closes #75.